### PR TITLE
Support generating APKs for multiple ABIs in one run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,10 +221,11 @@ execute_process(
 # Check if the detected DEVICE_ABI is among the supported ABIs
 list(FIND ABIS ${DEVICE_ABI} ABI_INDEX)
 
-# Install the APK for the detected ABI
-# Use -e (emulator) or -d (device) flags with adb if needed
+# Warn if the cnnected device's ABI is not supported
 if(ABI_INDEX EQUAL -1)
   message(WARNING "Connected device's ABI (${DEVICE_ABI}) is not supported. Please build for this ABI to use the 'install_apk' target.")
+# Install the APK for the detected ABI
+# Use -e (emulator) or -d (device) flags with adb if needed
 else()
   add_custom_target(install_apk
     COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${DEVICE_ABI}.apk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT DEFINED ABIS)
   set(ABIS "armeabi-v7a;arm64-v8a;x86;x86_64" CACHE STRING "Android ABIs")
 endif()
 
-# Set default API (minSdkVersion)
+# Set default API level (minSdkVersion)
 if(NOT DEFINED API_LEVEL)
   set(API_LEVEL "21" CACHE STRING "API level (minSdkVersion)")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,12 +9,22 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type (default Debug)" FORCE)
 endif()
 
-# Ensure that ANDROID_ABI, ANDROID_PLATFORM, and CMAKE_TOOLCHAIN_FILE are set
-foreach(var ANDROID_ABI ANDROID_PLATFORM CMAKE_TOOLCHAIN_FILE)
-  if(NOT DEFINED ${var})
-    message(FATAL_ERROR "${var} is not set. Make sure it's passed to CMake")
-  endif()
-endforeach()
+# Ensure that ANDROID_NDK_HOME is set
+if(DEFINED ENV{ANDROID_NDK_HOME})
+  set(ANDROID_NDK_HOME $ENV{ANDROID_NDK_HOME})
+else()
+  message(FATAL_ERROR "Environment variable ANDROID_NDK_HOME is not set. Please set it to proceed.")
+endif()
+
+# 
+if(NOT DEFINED ABIS)
+  set(ABIS "armeabi-v7a;arm64-v8a;x86;x86_64" CACHE STRING "Android ABIs")
+endif()
+
+# 
+if(NOT DEFINED API_LEVEL)
+  set(API_LEVEL "21" CACHE STRING "Minimum SDK version")
+endif()
 
 # Define the native library name
 set(APP_LIB_NAME main)
@@ -30,19 +40,21 @@ endif()
 include(ExternalProject)
 
 # Build the native library
-ExternalProject_Add(${APP_LIB_NAME}_${ANDROID_ABI}
-  SOURCE_DIR ${CMAKE_SOURCE_DIR}/app/src/main/c/
-  BINARY_DIR ${CMAKE_BINARY_DIR}/lib/${ANDROID_ABI}
-  CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-             -DANDROID_ABI=${ANDROID_ABI}
-             -DANDROID_PLATFORM=${ANDROID_PLATFORM}
-             -DAPP_LIB_NAME=${APP_LIB_NAME}
-             -DANDROID_EXTERNAL_HOME=${ANDROID_EXTERNAL_HOME}
-             -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-  BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/lib/${ANDROID_ABI}/lib${APP_LIB_NAME}.so
-  BUILD_ALWAYS 1
-  INSTALL_COMMAND ""
-)
+foreach(ABI IN LISTS ABIS)
+  ExternalProject_Add(${APP_LIB_NAME}_${ABI}
+    SOURCE_DIR ${CMAKE_SOURCE_DIR}/app/src/main/c/
+    BINARY_DIR ${CMAKE_BINARY_DIR}/lib/${ABI}
+    CMAKE_ARGS -DCMAKE_TOOLCHAIN_FILE=${ANDROID_NDK_HOME}/build/cmake/android.toolchain.cmake
+               -DANDROID_ABI=${ABI}
+               -DANDROID_PLATFORM=${API_LEVEL}
+               -DAPP_LIB_NAME=${APP_LIB_NAME}
+               -DANDROID_EXTERNAL_HOME=${ANDROID_EXTERNAL_HOME}
+               -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    BUILD_BYPRODUCTS ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so
+    BUILD_ALWAYS 1
+    INSTALL_COMMAND ""
+  )
+endforeach()
 
 # Ensure that ANDROID_HOME is set
 if(DEFINED ENV{ANDROID_HOME})
@@ -51,8 +63,8 @@ else()
   message(FATAL_ERROR "Environment variable ANDROID_HOME is not set. Please set it to proceed.")
 endif()
 
-# Set the APK output file name
-set(APK_OUTPUT_NAME ${PROJECT_NAME}_v${PROJECT_VERSION}_${ANDROID_ABI})
+# Set APK output file name
+set(APK_OUTPUT_NAME ${PROJECT_NAME}_v${PROJECT_VERSION})
 
 # Define the output directory for APKs and ensure it exists
 set(APK_OUTPUT_DIR outputs)
@@ -112,35 +124,38 @@ set(TARGET_SDK 36)
 # Path to the Android SDK platform JAR for linking
 set(ANDROID_JAR_PATH ${ANDROID_HOME}/platforms/android-${TARGET_SDK}/android.jar)
 
-# Create an APK by linking togather compiled resources, manifest, shared library, and JAR file
-add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.unaligned.apk
-  COMMAND aapt2 link
-          -o ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.unaligned.apk
-          ${COMPILED_RES_FILES}                        # Compiled resources
-          -I ${ANDROID_JAR_PATH}                       # Android platform JAR
-          --manifest ${ANDROID_MANIFEST_FILE}          # AndroidManifest.xml
-  COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.unaligned.apk lib/${ANDROID_ABI}/lib${APP_LIB_NAME}.so
-  DEPENDS ${ANDROID_MANIFEST_FILE}                                      # Manifest file as a dependency
-          ${COMPILED_RES_FILES}                                         # Compiled resources as dependencies
-          ${APP_LIB_NAME}_${ANDROID_ABI}
-          ${CMAKE_BINARY_DIR}/lib/${ANDROID_ABI}/lib${APP_LIB_NAME}.so  # Shared library as a dependency
-  COMMENT "Creating APK package"
-)
-add_custom_target(create_apk ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.unaligned.apk)
+# Create APKs by linking togather compiled resources, manifest, shared library, and JAR file 
+foreach(ABI IN LISTS ABIS)
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+    COMMAND aapt2 link
+            -o ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+            ${COMPILED_RES_FILES}                        # Compiled resources
+            -I ${ANDROID_JAR_PATH}                       # Android platform JAR
+            --manifest ${ANDROID_MANIFEST_FILE}          # AndroidManifest.xml
+    COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk lib/${ABI}/lib${APP_LIB_NAME}.so
+    DEPENDS ${ANDROID_MANIFEST_FILE}                                      # Manifest file as a dependency
+            ${COMPILED_RES_FILES}                                         # Compiled resources as dependencies
+            ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so          # Shared library as a dependency
+    COMMENT "Creating APK package (${ABI})"
+  )
+  add_custom_target(create_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk)
+endforeach()
 
 # Align the APK package for optimized installation on Android
-add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.aligned.apk
-  COMMAND zipalign -f                                  # Force overwrite
-          -p                                           # Page aligns uncompressed data
-          4                                            # Align ZIP to 4-byte boundaries
-          ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.unaligned.apk
-          ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.aligned.apk
-  DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.unaligned.apk
-  COMMENT "Aligning APK package"
-)
-add_custom_target(align_apk ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.aligned.apk)
+foreach(ABI IN LISTS ABIS)
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
+    COMMAND zipalign -f                                  # Force overwrite
+            -p                                           # Page aligns uncompressed data
+            4                                            # Align ZIP to 4-byte boundaries
+            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
+    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+    COMMENT "Aligning APK package (${ABI})"
+  )
+  add_custom_target(align_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk)
+endforeach()
 
 # Set keystore file path
 if(DEFINED ENV{KEYSTORE_FILE})
@@ -173,21 +188,23 @@ else()
 endif()
 
 # Sign the APK package
-add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
-         ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk.idsig
-  COMMAND apksigner sign
-          --ks ${KEYSTORE_FILE} --ks-pass pass:${KEYSTORE_PASS}
-          --ks-key-alias ${KEY_ALIAS} --key-pass pass:${KEY_PASS}
-          --out ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
-          ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.aligned.apk
-  DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.aligned.apk
-  COMMENT "Signing APK package"
-)
-add_custom_target(sign_apk ALL
-  DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
-          ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk.idsig
-)
+foreach(ABI IN LISTS ABIS)
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
+           ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk.idsig
+    COMMAND apksigner sign
+            --ks ${KEYSTORE_FILE} --ks-pass pass:${KEYSTORE_PASS}
+            --ks-key-alias ${KEY_ALIAS} --key-pass pass:${KEY_PASS}
+            --out ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
+            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
+    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
+    COMMENT "Signing APK package (${ABI})"
+  )
+  add_custom_target(sign_apk_${ABI} ALL
+    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
+            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk.idsig
+  )
+endforeach()
 
 # Set default USER_ID if not specified by user
 if(NOT DEFINED USER_ID)
@@ -196,11 +213,11 @@ endif()
 
 # Install APK on a connected Android emulator/device using ADB
 # NOTE: Use -e (emulator) or -d (device) parameters if necessary
-add_custom_target(install_apk
-  COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
-  DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
-  COMMENT "Installing APK package"
-)
+# add_custom_target(install_apk
+#  COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
+#  DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
+#  COMMENT "Installing APK package"
+#)
 
 # Define application package name for uninstallation
 set(APK_PACKAGE_NAME "com.oussamateyib.helloworld")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,25 +9,19 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type (default Debug)" FORCE)
 endif()
 
+# Ensure that ANDROID_HOME is set
+if(DEFINED ENV{ANDROID_HOME})
+  set(ANDROID_HOME $ENV{ANDROID_HOME})
+else()
+  message(FATAL_ERROR "Environment variable ANDROID_HOME is not set. Please set it to proceed.")
+endif()
+
 # Ensure that ANDROID_NDK_HOME is set
 if(DEFINED ENV{ANDROID_NDK_HOME})
   set(ANDROID_NDK_HOME $ENV{ANDROID_NDK_HOME})
 else()
   message(FATAL_ERROR "Environment variable ANDROID_NDK_HOME is not set. Please set it to proceed.")
 endif()
-
-# 
-if(NOT DEFINED ABIS)
-  set(ABIS "armeabi-v7a;arm64-v8a;x86;x86_64" CACHE STRING "Android ABIs")
-endif()
-
-# 
-if(NOT DEFINED API_LEVEL)
-  set(API_LEVEL "21" CACHE STRING "Minimum SDK version")
-endif()
-
-# Define the native library name
-set(APP_LIB_NAME main)
 
 # Ensure that ANDROID_EXTERNAL_HOME is set
 if(DEFINED ENV{ANDROID_EXTERNAL_HOME})
@@ -36,10 +30,23 @@ else()
   message(FATAL_ERROR "Environment variable ANDROID_EXTERNAL_HOME is not set. Please set it to proceed.")
 endif()
 
+# Set default ABIs
+if(NOT DEFINED ABIS)
+  set(ABIS "armeabi-v7a;arm64-v8a;x86;x86_64" CACHE STRING "Android ABIs")
+endif()
+
+# Set default API (minSdkVersion)
+if(NOT DEFINED API_LEVEL)
+  set(API_LEVEL "21" CACHE STRING "API level (minSdkVersion)")
+endif()
+
+# Define the native library name
+set(APP_LIB_NAME main)
+
 # Load the ExternalProject module
 include(ExternalProject)
 
-# Build the native library
+# Build the native library for each ABI
 foreach(ABI IN LISTS ABIS)
   ExternalProject_Add(${APP_LIB_NAME}_${ABI}
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/app/src/main/c/
@@ -55,13 +62,6 @@ foreach(ABI IN LISTS ABIS)
     INSTALL_COMMAND ""
   )
 endforeach()
-
-# Ensure that ANDROID_HOME is set
-if(DEFINED ENV{ANDROID_HOME})
-  set(ANDROID_HOME $ENV{ANDROID_HOME})
-else()
-  message(FATAL_ERROR "Environment variable ANDROID_HOME is not set. Please set it to proceed.")
-endif()
 
 # Set APK output file name
 set(APK_OUTPUT_NAME ${PROJECT_NAME}_v${PROJECT_VERSION})
@@ -124,7 +124,7 @@ set(TARGET_SDK 36)
 # Path to the Android SDK platform JAR for linking
 set(ANDROID_JAR_PATH ${ANDROID_HOME}/platforms/android-${TARGET_SDK}/android.jar)
 
-# Create APKs by linking togather compiled resources, manifest, shared library, and JAR file 
+# Create the APK packages by linking togather compiled resources, manifest, shared library, and JAR file 
 foreach(ABI IN LISTS ABIS)
   add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
@@ -142,7 +142,7 @@ foreach(ABI IN LISTS ABIS)
   add_custom_target(create_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk)
 endforeach()
 
-# Align the APK package for optimized installation on Android
+# Align the APK packages for optimized installation on Android
 foreach(ABI IN LISTS ABIS)
   add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
@@ -187,7 +187,7 @@ else()
   message(FATAL_ERROR "Neither KEY_PASS nor KEYSTORE_PASS environment variables are set. One of them must be defined.")
 endif()
 
-# Sign the APK package
+# Sign the APK packages
 foreach(ABI IN LISTS ABIS)
   add_custom_command(
     OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,33 +206,20 @@ foreach(ABI IN LISTS ABIS)
   )
 endforeach()
 
-# Set default USER_ID if not specified by user
+# Set default user ID
 if(NOT DEFINED USER_ID)
-  set(USER_ID 0 CACHE STRING "User ID (default 0)")
+  set(USER_ID 0 CACHE STRING "User ID (default 0, the primary user)")
 endif()
 
-# Retrieve the ABI of the connected Android device or emulator
-execute_process(
-  COMMAND adb shell getprop ro.product.cpu.abi
-  OUTPUT_VARIABLE DEVICE_ABI
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-# Check if the detected DEVICE_ABI is among the supported ABIs
-list(FIND ABIS ${DEVICE_ABI} ABI_INDEX)
-
-# Warn if the connected device's ABI is not supported
-if(ABI_INDEX EQUAL -1)
-  message(WARNING "Connected device's ABI (${DEVICE_ABI}) is not supported. Please build for this ABI to use the 'install_apk' target.")
-# Install the APK for the detected ABI
+# Install the APK packages
 # Use -e (emulator) or -d (device) flags with adb if needed
-else()
-  add_custom_target(install_apk
-    COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${DEVICE_ABI}.apk
-    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${DEVICE_ABI}.apk
-    COMMENT "Installing APK package (${DEVICE_ABI})"
+foreach(ABI IN LISTS ABIS)
+  add_custom_target(install_apk_${ABI}
+    COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
+    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
+    COMMENT "Installing APK package (${ABI})"
   )
-endif()
+endforeach()
 
 # Define the application package name
 set(APK_PACKAGE_NAME "com.oussamateyib.helloworld")
@@ -245,7 +232,7 @@ add_custom_target(uninstall_apk
 
 # Display the ABI of the connected device/emulator
 add_custom_target(check_device_abi
-  COMMAND ${CMAKE_COMMAND} -E echo ${DEVICE_ABI}
+  COMMAND adb shell getprop ro.product.cpu.abi
   COMMENT "Checking device ABI compatibility"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ execute_process(
 # Check if the detected DEVICE_ABI is among the supported ABIs
 list(FIND ABIS ${DEVICE_ABI} ABI_INDEX)
 
-# Warn if the cnnected device's ABI is not supported
+# Warn if the connected device's ABI is not supported
 if(ABI_INDEX EQUAL -1)
   message(WARNING "Connected device's ABI (${DEVICE_ABI}) is not supported. Please build for this ABI to use the 'install_apk' target.")
 # Install the APK for the detected ABI

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,30 +211,44 @@ if(NOT DEFINED USER_ID)
   set(USER_ID 0 CACHE STRING "User ID (default 0)")
 endif()
 
-# Install APK on a connected Android emulator/device using ADB
-# NOTE: Use -e (emulator) or -d (device) parameters if necessary
-# add_custom_target(install_apk
-#  COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
-#  DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}.apk
-#  COMMENT "Installing APK package"
-#)
+# Retrieve the ABI of the connected Android device or emulator
+execute_process(
+  COMMAND adb shell getprop ro.product.cpu.abi
+  OUTPUT_VARIABLE DEVICE_ABI
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
 
-# Define application package name for uninstallation
+# Check if the detected DEVICE_ABI is among the supported ABIs
+list(FIND ABIS ${DEVICE_ABI} ABI_INDEX)
+
+# Install the APK for the detected ABI
+# Use -e (emulator) or -d (device) flags with adb if needed
+if(ABI_INDEX EQUAL -1)
+  message(WARNING "Connected device's ABI (${DEVICE_ABI}) is not supported. Please build for this ABI to use the 'install_apk' target.")
+else()
+  add_custom_target(install_apk
+    COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${DEVICE_ABI}.apk
+    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${DEVICE_ABI}.apk
+    COMMENT "Installing APK package (${DEVICE_ABI})"
+  )
+endif()
+
+# Define the application package name
 set(APK_PACKAGE_NAME "com.oussamateyib.helloworld")
 
-# Uninstall the application from the connected device
+# Uninstall the application from the connected device/emulator
 add_custom_target(uninstall_apk
   COMMAND adb uninstall --user ${USER_ID} ${APK_PACKAGE_NAME}
   COMMENT "Uninstalling APK package"
 )
 
-# Check the supported ABI for the connected device
+# Display the ABI of the connected device/emulator
 add_custom_target(check_device_abi
-  COMMAND adb shell getprop ro.product.cpu.abi
+  COMMAND ${CMAKE_COMMAND} -E echo ${DEVICE_ABI}
   COMMENT "Checking device ABI compatibility"
 )
 
-# List all current users on the connected Android emulator/device
+# List all current users on the connected Android device/emulator
 add_custom_target(list_users
   COMMAND adb shell pm list users
   COMMENT "Listing current users on device"

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ This is a simple Android application written in C that displays **"Hello, World!
 Before you begin, ensure you have the following installed:
 
 - **Android SDK**: Version 26.0.2 or higher.
-- **Android NDK**
+- **Android NDK**: Version r25 or higher.
 - **zip**
 - **CMake**: Version 3.22.1 or higher.
 - **Build System**: Ninja is recommended for faster builds.
-- **Java Development Kit (JDK)**
+- **Java Development Kit (JDK)**: JDK 11 or newer.
 - **raylib**: Follow the [official instructions](https://github.com/raysan5/raylib/wiki/Working-for-Android) to download and build raylib as a static library for Android.
 - All required executables are in the system's `PATH`.
 
@@ -25,13 +25,14 @@ Before you begin, ensure you have the following installed:
 > - Target SDK version: `36`
 > - Minimum SDK version: `21`
 > 
-> Any changes to these defaults require corresponding updates to both the CMake and XML configuration files.
+> Any changes to these defaults require corresponding updates to CMake and XML configuration files.
 
 ### Environment Variables
 
 Before building the project, ensure the following environment variables are set:
 
 - **ANDROID_HOME**: Path to the Android SDK installation.
+- **ANDROID_NDK_HOME**: Path to the Android NDK installation.
 - **ANDROID_EXTERNAL_HOME**: Path to the installation of external Android libraries. This directory must have the following structure:
 
   ```plaintext
@@ -49,26 +50,28 @@ Before building the project, ensure the following environment variables are set:
 
 ### Build Instructions
 
-Replace placeholders with your values and execute the commands:
+Replace placeholders with your own values before running the commands.
 
-1. **Configure the project**:
+---
+
+1. **Configure the Project Using CMake**:
 
    ```
    cmake -B <Build-Directory> \
-         -DCMAKE_TOOLCHAIN_FILE=<NDK-Path>/build/cmake/android.toolchain.cmake \
-         -DANDROID_ABI=<ABI> \
-         -DANDROID_PLATFORM=<API-Level> \
-         -DCMAKE_BUILD_TYPE=<Build-Type> \
-         -DUSER_ID=<User-ID>
+         -G "<Build-System>" \
+         [-DCMAKE_BUILD_TYPE=<Build-Type>] \
+         [-DABIS="<ABI-List>"] \
+         [-DAPI_Level=<API-Level>] \
+         [-DUSER_ID=<User-ID>]
    ```
 
-   **Parameters:**
-   - **Build Directory**: Name of the build directory (e.g., `Build/arm64-v8a`).
-   - **NDK Path**: Path to the Android NDK installation.
-   - **ABI**: Target Application Binary Interface (e.g., `arm64-v8a`, `armeabi-v7a`).
-   - **API Level**: Minimum Android API level to support (e.g., `21`).
-   - **Build-Type** *(optional)*: Specifies the build type; defaults to `Debug`.
-   - **USER_ID** *(optional)*: Android user ID to install the app for; defaults to `0`, the primary user.
+   **Explanation of Parameters:**
+   - `-B <Build-Directory>`: Specifies the build output directory (e.g., `Build`).
+   - `-G "<Build-System>"`: Generator name (e.g., `Ninja`, `Unix Makefiles`, etc.).
+   - `-DCMAKE_BUILD_TYPE=<Build-Type>` *(optional)*: Set to `Debug`, `Release`, `RelWithDebInfo`, or `MinSizeRel`. Default is `Debug`.
+   - `-DABIS="<ABI-List>"` *(optional)*: Semicolon-separated list of target ABIs. Default: `armeabi-v7a;arm64-v8a;x86;x86_64`.
+   - `-DAPI_Level=<API-Level>` *(optional)*: Minimum Android API level. Default: `21`.
+   - `-DUSER_ID=<User-ID>` *(optional)*: Target Android user ID for app installation. Default: `0` (primary user).
 
 2. **Build the project**:
 
@@ -76,15 +79,17 @@ Replace placeholders with your values and execute the commands:
    cmake --build <Build-Directory>
    ```
 
-   This command compiles the native code and generates the APK.
+   This command compiles the native code and builds APKs for all ABIs specified in the `ABIS` variable.
 
-3. **Install on a connected device**:
+3. **Install on a connected device or emulator**:
 
-   To install the APK on a connected device, run:
+   To install the APK on a connected device or emulator, run:
 
    ```
    cmake --build <Build-Directory> --target install_apk
    ```
+   
+   This command automatically detects the ABI of the connected device or emulator, builds the corresponding native code and APK (if not already built), and installs it on the target.
 
 ### Useful Commands
 
@@ -93,13 +98,13 @@ Replace placeholders with your values and execute the commands:
    cmake --build <Build-Directory> --target clean
    ```
 
-- **Uninstall APK**: Remove the app from the connected device.
+- **Uninstall APK**: Remove the app from the connected device or emulator.
 
    ```
    cmake --build <Build-Directory> --target uninstall_apk
    ```
 
-- **Check Device ABI**: Confirm the ABI of the connected device.
+- **Check Device ABI**: Get the ABI of the connected device or emulator.
 
    ```
    cmake --build <Build-Directory> --target check_device_abi

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Before you begin, ensure you have the following installed:
 - **Build System**: Ninja is recommended for faster builds.
 - **Java Development Kit (JDK)**: JDK 11 or newer.
 - **raylib**: Follow the [official instructions](https://github.com/raysan5/raylib/wiki/Working-for-Android) to download and build raylib as a static library for Android.
-- All required executables are in the system's `PATH`.
+> ✅ Make sure all required tools are available in your system's PATH.
 
 > [!NOTE]
 > By default:

--- a/README.md
+++ b/README.md
@@ -86,10 +86,11 @@ Replace placeholders with your own values before running the commands.
    To install the APK on a connected device or emulator, run:
 
    ```
-   cmake --build <Build-Directory> --target install_apk
+   cmake --build <Build-Directory> --target install_apk_<ABI-Name>
    ```
    
-   This command automatically detects the ABI of the connected device or emulator, builds the corresponding native code and APK (if not already built), and installs it on the target.
+   This command builds the native code and APK for the specified ABI (if not already built), and installs it on the connected target.
+   > Replace `<ABI-Name>` with one of the build's supported ABIs.
 
 ### Useful Commands
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR extends the build system to compile, package, align, sign, and install APKs for multiple ABIs in a single CMake run, replacing the previous single-ABI workflow.

### Changes

- Replaced single-ABI native library compilation with a loop over an `ABIS` list, building one `ExternalProject_Add` target per ABI.
- Added `ANDROID_NDK_HOME` environment variable requirement and derived the CMake toolchain file path from it.
- Introduced default `ABIS` and `API_LEVEL` cache variables, replacing the previously required `ANDROID_ABI` and `ANDROID_PLATFORM` arguments.
- Updated APK output naming to drop the single-ABI suffix from the base name and append the ABI per generated package.
- Converted APK creation, alignment, signing, and installation steps into per-ABI loops with per-ABI custom targets.
- Updated `README.md` to document `ANDROID_NDK_HOME`, the new `ABIS`/`API_LEVEL`/generator CLI parameters, and per-ABI install targets.
- Added minimum version requirements for the Android NDK and JDK in the prerequisites section.