### PR TITLE
Support generating a universal APK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,22 +124,35 @@ set(TARGET_SDK 36)
 # Path to the Android SDK platform JAR for linking
 set(ANDROID_JAR_PATH ${ANDROID_HOME}/platforms/android-${TARGET_SDK}/android.jar)
 
-# Create the APK packages by linking togather compiled resources, manifest, shared library, and JAR file 
+# Create APK packages by linking togather compiled resources, manifest, and JAR file 
 foreach(ABI IN LISTS ABIS)
   add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk
     COMMAND aapt2 link
-            -o ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+            -o ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk
             ${COMPILED_RES_FILES}                        # Compiled resources
             -I ${ANDROID_JAR_PATH}                       # Android platform JAR
             --manifest ${ANDROID_MANIFEST_FILE}          # AndroidManifest.xml
-    COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk lib/${ABI}/lib${APP_LIB_NAME}.so
-    DEPENDS ${ANDROID_MANIFEST_FILE}                                      # Manifest file as a dependency
-            ${COMPILED_RES_FILES}                                         # Compiled resources as dependencies
-            ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so          # Shared library as a dependency
+    DEPENDS ${ANDROID_MANIFEST_FILE}                     # Manifest file as a dependency
+            ${COMPILED_RES_FILES}                        # Compiled resources as dependencies
     COMMENT "Creating APK package (${ABI})"
   )
-  add_custom_target(create_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk)
+  add_custom_target(create_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk)
+endforeach()
+
+# Add shared libraries to APK packages 
+foreach(ABI IN LISTS ABIS)
+  add_custom_command(
+    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+    COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk lib/${ABI}/lib${APP_LIB_NAME}.so
+	COMMAND ${CMAKE_COMMAND} -E rename
+            "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk"
+            "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk"
+    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
+            ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so                      # Shared libraries as dependencies
+    COMMENT "Adding shared libraries (${ABI})"
+  )
+  add_custom_target(add_shared_libs_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk)
 endforeach()
 
 # Align the APK packages for optimized installation on Android

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,10 @@ foreach(ABI IN LISTS ABIS)
   )
 endforeach()
 
+# Append "universal" to ABIS to support fat APKs
+set(ORIGINAL_ABIS ${ABIS})
+list(APPEND ABIS "universal")
+
 # Set APK output file name
 set(APK_OUTPUT_NAME ${PROJECT_NAME}_v${PROJECT_VERSION})
 
@@ -142,16 +146,34 @@ endforeach()
 
 # Add shared libraries to APK packages 
 foreach(ABI IN LISTS ABIS)
-  add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
-    COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk lib/${ABI}/lib${APP_LIB_NAME}.so
-	COMMAND ${CMAKE_COMMAND} -E rename
-            "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk"
-            "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk"
-    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
-            ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so                      # Shared libraries as dependencies
-    COMMENT "Adding shared libraries (${ABI})"
-  )
+  if(NOT ABI STREQUAL "universal")
+    add_custom_command(
+      OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+      COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk lib/${ABI}/lib${APP_LIB_NAME}.so
+	  COMMAND ${CMAKE_COMMAND} -E rename
+              "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk"
+              "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk"
+      DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
+              ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so                      # Shared libraries as dependencies
+      COMMENT "Adding shared libraries (${ABI})"
+    )
+  else()
+    set(SHARED_LIBS "")
+    foreach(ORIGINAL_ABI IN LISTS ORIGINAL_ABIS)
+	  list(APPEND SHARED_LIBS "lib/${ORIGINAL_ABI}/lib${APP_LIB_NAME}.so")
+	endforeach()
+	  
+    add_custom_command(
+      OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+      COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk ${SHARED_LIBS}
+      COMMAND ${CMAKE_COMMAND} -E rename
+              "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk"
+              "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk"
+      DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
+              ${SHARED_LIBS}                                                            # Shared libraries as dependencies
+      COMMENT "Adding shared libraries (${ABI})"
+    )
+  endif()
   add_custom_target(add_shared_libs_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk)
 endforeach()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,20 +144,23 @@ foreach(ABI IN LISTS ABIS)
   add_custom_target(create_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk)
 endforeach()
 
-# Add shared libraries to APK packages 
+# Add shared libraries to APK packages for each ABI
 foreach(ABI IN LISTS ABIS)
+  # For ABI-specific APKs (excluding "universal")
   if(NOT ABI STREQUAL "universal")
     add_custom_command(
       OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
       COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk lib/${ABI}/lib${APP_LIB_NAME}.so
-	  COMMAND ${CMAKE_COMMAND} -E rename
+	  COMMAND ${CMAKE_COMMAND} -E copy
               "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk"
               "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk"
       DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
               ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so                      # Shared libraries as dependencies
       COMMENT "Adding shared libraries (${ABI})"
     )
+  # For the universal APK (includes shared libraries for all ABIs)
   else()
+    # Gather all ABI-specific shared libraries into a list
     set(SHARED_LIBS "")
     foreach(ORIGINAL_ABI IN LISTS ORIGINAL_ABIS)
 	  list(APPEND SHARED_LIBS "lib/${ORIGINAL_ABI}/lib${APP_LIB_NAME}.so")
@@ -166,7 +169,7 @@ foreach(ABI IN LISTS ABIS)
     add_custom_command(
       OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
       COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk ${SHARED_LIBS}
-      COMMAND ${CMAKE_COMMAND} -E rename
+      COMMAND ${CMAKE_COMMAND} -E copy
               "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk"
               "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk"
       DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency

--- a/README.md
+++ b/README.md
@@ -80,16 +80,25 @@ Replace placeholders with your values before running the commands.
    cmake --build <Build-Directory>
    ```
 
-   Compiles the native code and builds APKs for all configured ABIs.
+   This command compiles the native code and generates APKs for all configured ABIs, along with a universal APK that is compatible with all devices.
 
 3. **Install on a connected device or emulator**
 
+   To install the APK for a specific ABI:
    ```
    cmake --build <Build-Directory> --target install_apk_<ABI-Name>
    ```
    
-   Compiles the native code and build APK for the specified ABI (if not already built), and installs it on the connected target.
+   This command builds the native code and the APK for the specified ABI (if not already built), and installs it on the connected device or emulator.
    > Replace `<ABI-Name>` with one of the configured ABIs.
+
+   To install the universal APK:
+   ```
+   cmake --build <Build-Directory> --target install_apk_universal
+   ```
+   
+   This command builds the native code and the universal APK covering all configured ABIs (if not already built), and installs it on the connected target.
+
 
 ### Useful Commands
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds support for generating a universal (fat) APK alongside the per-ABI APKs, by bundling shared libraries for all configured ABIs into a single package. It restructures APK creation into a base-APK step followed by a separate shared-library-injection step, so the universal APK can reuse the same base and pull in every ABI's native library, and updates the README to document how to build and install it.

### Changes

- Appended `universal` to the `ABIS` list while preserving the original per-ABI list in `ORIGINAL_ABIS`.
- Split APK creation into a base APK step (`aapt2 link` producing a `.base.apk`) and a separate step that adds shared libraries to produce the `.unaligned.apk`.
- Added a per-ABI branch that zips the single matching shared library into the base APK for standard ABIs.
- Added a `universal` branch that collects every ABI's shared library from `ORIGINAL_ABIS` and zips them all into the base APK.
- Introduced `add_shared_libs_<ABI>` custom targets to run the new library-injection step for each ABI, including `universal`.
- Updated `README.md` to describe universal APK generation during the build step.
- Documented the `install_apk_universal` target for installing the universal APK on a connected device or emulator.