### PR TITLE
Use the Android SDK’s debug certificate for debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,34 +195,53 @@ foreach(ABI IN LISTS ABIS)
   add_custom_target(align_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk)
 endforeach()
 
-# Set keystore file path
-if(DEFINED ENV{KEYSTORE_FILE})
-  set(KEYSTORE_FILE $ENV{KEYSTORE_FILE})
-else()
-  message(FATAL_ERROR "Environment variable KEYSTORE_FILE is not set. Please set it to proceed.")
-endif()
+# Check if the build type is Debug
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  # Determine the user's home directory based on platform
+  if(WIN32)
+    set(USER_HOME "$ENV{USERPROFILE}")
+  else()
+    set(USER_HOME "$ENV{HOME}")
+  endif()
 
-# Set keystore password
-if(DEFINED ENV{KEYSTORE_PASS})
-  set(KEYSTORE_PASS $ENV{KEYSTORE_PASS})
-else()
-  message(FATAL_ERROR "Environment variable KEYSTORE_PASS is not set. Please set it to proceed.")
-endif()
+  # Use the default Android debug keystore for debug builds
+  set(KEYSTORE_PATH "${USER_HOME}/.android/debug.keystore")
+  set(KEYSTORE_PASS "android")              # Default password for debug keystore
+  set(KEY_ALIAS "androiddebugkey")          # Default alias for debug key
+  set(KEY_PASS "android")                   # Default password for debug key
 
-# Set key alias for signing
-if(DEFINED ENV{KEY_ALIAS})
-  set(KEY_ALIAS $ENV{KEY_ALIAS})
+# For release builds, require all signing credentials via environment variables
 else()
-  message(FATAL_ERROR "Environment variable KEY_ALIAS is not set. Please set it to proceed.")
-endif()
+  # Keystore path (must be set)
+  if(DEFINED ENV{KEYSTORE_PATH})
+    set(KEYSTORE_PATH $ENV{KEYSTORE_PATH})
+  else()
+    message(FATAL_ERROR "Environment variable KEYSTORE_PATH is not set. Please set it to proceed.")
+  endif()
 
-# Set key password or fallback to keystore password
-if(DEFINED ENV{KEY_PASS})
-  set(KEY_PASS $ENV{KEY_PASS})
-elseif(DEFINED ENV{KEYSTORE_PASS})
-  set(KEY_PASS $ENV{KEYSTORE_PASS})
-else()
-  message(FATAL_ERROR "Neither KEY_PASS nor KEYSTORE_PASS environment variables are set. One of them must be defined.")
+  # Keystore password (must be set)
+  if(DEFINED ENV{KEYSTORE_PASS})
+    set(KEYSTORE_PASS $ENV{KEYSTORE_PASS})
+  else()
+    message(FATAL_ERROR "Environment variable KEYSTORE_PASS is not set. Please set it to proceed.")
+  endif()
+
+  # Key alias (must be set)
+  if(DEFINED ENV{KEY_ALIAS})
+    set(KEY_ALIAS $ENV{KEY_ALIAS})
+  else()
+    message(FATAL_ERROR "Environment variable KEY_ALIAS is not set. Please set it to proceed.")
+  endif()
+
+  # Key password (optional: fallback to keystore password if not set)
+  if(DEFINED ENV{KEY_PASS})
+    set(KEY_PASS $ENV{KEY_PASS})
+  elseif(DEFINED ENV{KEYSTORE_PASS})
+    set(KEY_PASS $ENV{KEYSTORE_PASS})
+  else()
+    message(FATAL_ERROR "Neither KEY_PASS nor KEYSTORE_PASS environment variables are set. One of them must be defined.")
+  endif()
+
 endif()
 
 # Sign the APK packages
@@ -231,7 +250,7 @@ foreach(ABI IN LISTS ABIS)
     OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk.idsig
     COMMAND apksigner sign
-            --ks ${KEYSTORE_FILE} --ks-pass pass:${KEYSTORE_PASS}
+            --ks ${KEYSTORE_PATH} --ks-pass pass:${KEYSTORE_PASS}
             --ks-key-alias ${KEY_ALIAS} --key-pass pass:${KEY_PASS}
             --out ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
             ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Before building the project, ensure the following environment variables are set:
       ├── <ABI>/            # ABI name (e.g., armeabi-v7a, arm64-v8a)
       │   └── libraylib.a   # Static raylib library for the ABI
   ```
-- **KEYSTORE_FILE** — Path to the keystore used for signing
+  
+If you plan to build a release version of the app, the following variables must also be set (for signing):
+- **KEYSTORE_PATH** — Path to the keystore used for signing
 - **KEYSTORE_PASS** — Keystore password
 - **KEY_ALIAS** — Alias of the key in the keystore
 - **KEY_PASS** *(optional)* — Key password (default: **KEYSTORE_PASS**)


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR changes the signing configuration to use the Android SDK's default debug keystore for debug builds, removing the need to manually provide signing credentials during development. For release builds, all signing credentials remain required and must be supplied via environment variables.

### Changes

- Wrapped the signing configuration in a check for `CMAKE_BUILD_TYPE STREQUAL "Debug"`.
- Added detection of the user's home directory based on platform (`USERPROFILE` on Windows, `HOME` otherwise).
- Set the debug build to use the default Android debug keystore, password, alias, and key password automatically.
- Updated `README.md` to clarify that signing variables are only required for release builds.

### Related Issues

- Closes #7 