### PR TITLE
Support generating Android App Bundles (AAB)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ endforeach()
 
 # Create an Android App Bundle (AAB) from compiled resources and native libraries
 add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+  OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab
   # Link compiled resource files into an APK (intermediate step)
   COMMAND aapt2 link
           --proto-format                               # Use proto format for compatibility with bundletool
@@ -310,27 +310,20 @@ add_custom_command(
   COMMAND zip -u ${APP_OUTPUT_DIR}/temp/base.zip ${SHARED_LIBS}
   # Remove any existing unsigned AAB to avoid conflicts
   COMMAND ${CMAKE_COMMAND} -E remove -f ${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
-  # Build the final AAB file from base.
+  # Build the AAB file from base.zip
   COMMAND bundletool build-bundle --modules=${APP_OUTPUT_DIR}/temp/base.zip --output=${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
-  DEPENDS ${ANDROID_MANIFEST_FILE}                     # Manifest file as a dependency
-          ${COMPILED_RES_FILES}                        # Compiled resources as dependencies
-          ${SHARED_LIBS}                               # Shared libraries as dependencies
-  COMMENT "Creating AAB bundle"
-)
-add_custom_target(create_aab DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab)
-
-# Sign the AAB bundle
-add_custom_command(
-  OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab
+  # Sign the AAB bundle
   COMMAND jarsigner
           -keystore ${KEYSTORE_PATH} -storepass ${KEYSTORE_PASS}
           -signedjar ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab
           ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
           ${KEY_ALIAS}
-  DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
-  COMMENT "Signing AAB bundle"
+  DEPENDS ${ANDROID_MANIFEST_FILE}                     # Manifest file as a dependency
+          ${COMPILED_RES_FILES}                        # Compiled resources as dependencies
+          ${SHARED_LIBS}                               # Shared libraries as dependencies
+  COMMENT "Creating AAB bundle"
 )
-add_custom_target(sign_aab DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab)
+add_custom_target(create_aab DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab)
 
 # Uninstall the application from the connected device/emulator
 add_custom_target(uninstall_apk
@@ -352,11 +345,11 @@ add_custom_target(list_users
 
 # Define a list of untracked intermediate files to remove on clean
 set(TEMP_FILES
-   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/output.apk
-   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base/manifest/AndroidManifest.xml
-   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base/resources.pb
-   ${TEMP_RES_FILES}
-   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base.zip
+  ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/output.apk
+  ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base/manifest/AndroidManifest.xml
+  ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base/resources.pb
+  ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base.zip
+  ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
 )
 # Add expected intermediate resource files to the list
 foreach(res_file IN LISTS RES_FILES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -343,10 +343,13 @@ add_custom_target(uninstall_app
   COMMENT "Uninstalling the app package"
 )
 
-# Display the ABI of the connected device/emulator
-add_custom_target(check_device_abi
+# Display the supported ABIs on the connected device/emulator
+add_custom_target(check_abi
+  COMMAND ${CMAKE_COMMAND} -E echo "Primary ABI:"
   COMMAND adb shell getprop ro.product.cpu.abi
-  COMMENT "Checking device ABI compatibility"
+  COMMAND ${CMAKE_COMMAND} -E echo "Supported ABIs:"
+  COMMAND adb shell getprop ro.product.cpu.abilist
+  COMMENT "Checking ABI compatibility"
 )
 
 # Define a list of untracked intermediate files to remove on clean

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,10 +303,11 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E chdir ${APP_OUTPUT_DIR}/temp/base zip -r ../base.zip *
   # Add native shared libraries to the zip
   COMMAND zip -u ${APP_OUTPUT_DIR}/temp/base.zip ${SHARED_LIBS}
-  # Remove any existing unsigned AAB to avoid conflicts
-  COMMAND ${CMAKE_COMMAND} -E remove -f ${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
   # Build the AAB file from base.zip
-  COMMAND bundletool build-bundle --modules=${APP_OUTPUT_DIR}/temp/base.zip --output=${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+  COMMAND bundletool build-bundle
+          --modules=${APP_OUTPUT_DIR}/temp/base.zip
+          --output=${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+          --overwrite
   # Sign the AAB bundle
   COMMAND jarsigner
           -keystore ${KEYSTORE_PATH} -storepass ${KEYSTORE_PASS}
@@ -322,8 +323,6 @@ add_custom_target(create_aab DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP
 
 # Install the AAB bundle
 add_custom_target(install_aab
-  # Remove any existing .apks file to avoid conflicts
-  COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.apks
   # Build the APK set (.apks) from the AAB bundle
   COMMAND bundletool build-apks
           --bundle=${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab
@@ -331,6 +330,7 @@ add_custom_target(install_aab
           --ks ${KEYSTORE_PATH} --ks-pass pass:${KEYSTORE_PASS}
           --ks-key-alias ${KEY_ALIAS} --key-pass pass:${KEY_PASS}
           --connected-device
+          --overwrite
   # Install the generated .apks to the connected device
   COMMAND bundletool install-apks --apks=${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.apks
   DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,18 @@ if(NOT DEFINED API_LEVEL)
   set(API_LEVEL "21" CACHE STRING "API level (minSdkVersion)")
 endif()
 
-# Define the native library name
+# Set default user ID
+if(NOT DEFINED USER_ID)
+  set(USER_ID 0 CACHE STRING "User ID (default 0, the primary user)")
+endif()
+
+# Set the app output file name
+set(APP_OUTPUT_NAME ${PROJECT_NAME}_v${PROJECT_VERSION})
+
+# Set the app package name
+set(APP_PACKAGE_NAME "com.oussamateyib.helloworld")
+
+# Set the native library name
 set(APP_LIB_NAME main)
 
 # Load the ExternalProject module
@@ -63,20 +74,25 @@ foreach(ABI IN LISTS ABIS)
   )
 endforeach()
 
-# Append "universal" to ABIS to support fat APKs
-set(ORIGINAL_ABIS ${ABIS})
+# Gather all ABI-specific shared libraries into a list
+set(SHARED_LIBS "")
+foreach(ABI IN LISTS ABIS)
+  list(APPEND SHARED_LIBS "lib/${ABI}/lib${APP_LIB_NAME}.so")
+endforeach()
+
+# Append 'universal' to ABIS to support generating a fat APK
 list(APPEND ABIS "universal")
-
-# Set APK output file name
-set(APK_OUTPUT_NAME ${PROJECT_NAME}_v${PROJECT_VERSION})
-
+	  
 # Define the output directory for APKs and ensure it exists
-set(APK_OUTPUT_DIR outputs)
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR})
+set(APP_OUTPUT_DIR outputs)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR})
+
+# Ensure the temporary directory exists for intermediate files
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp)
 
 # Define the directory for compiled resources and ensure it exists
-set(APK_COMPILED_RES_DIR ${APK_OUTPUT_DIR}/compiled_res)
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${APK_COMPILED_RES_DIR})
+set(APP_COMPILED_RES_DIR ${APP_OUTPUT_DIR}/temp/compiled_res)
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/${APP_COMPILED_RES_DIR})
 
 # Define the resource directory
 set(RES_DIR ${CMAKE_SOURCE_DIR}/app/src/main/res)
@@ -107,15 +123,15 @@ foreach(res_file IN LISTS RES_FILES)
   endif()
 	
   # Append expected compiled .flat file
-  list(APPEND COMPILED_RES_FILES "${APK_COMPILED_RES_DIR}/${res_file_relative_path}.flat")
+  list(APPEND COMPILED_RES_FILES "${APP_COMPILED_RES_DIR}/${res_file_relative_path}.flat")
 endforeach()
 
-# Compile APK resource files
+# Compile the app resource files
 add_custom_command(
   OUTPUT ${COMPILED_RES_FILES}
   COMMAND aapt2 compile
           ${RES_FILES}
-          -o ${CMAKE_BINARY_DIR}/${APK_COMPILED_RES_DIR}
+          -o ${CMAKE_BINARY_DIR}/${APP_COMPILED_RES_DIR}
   DEPENDS ${RES_FILES}                    # Resource files as dependencies
   COMMENT "Compiling APK resources"
 )
@@ -131,9 +147,9 @@ set(ANDROID_JAR_PATH ${ANDROID_HOME}/platforms/android-${TARGET_SDK}/android.jar
 # Create APK packages by linking togather compiled resources, manifest, and JAR file 
 foreach(ABI IN LISTS ABIS)
   add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk
+    OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk
     COMMAND aapt2 link
-            -o ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk
+            -o ${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk
             ${COMPILED_RES_FILES}                        # Compiled resources
             -I ${ANDROID_JAR_PATH}                       # Android platform JAR
             --manifest ${ANDROID_MANIFEST_FILE}          # AndroidManifest.xml
@@ -141,7 +157,7 @@ foreach(ABI IN LISTS ABIS)
             ${COMPILED_RES_FILES}                        # Compiled resources as dependencies
     COMMENT "Creating APK package (${ABI})"
   )
-  add_custom_target(create_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk)
+  add_custom_target(create_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk)
 endforeach()
 
 # Add shared libraries to APK packages for each ABI
@@ -149,50 +165,44 @@ foreach(ABI IN LISTS ABIS)
   # For ABI-specific APKs (excluding "universal")
   if(NOT ABI STREQUAL "universal")
     add_custom_command(
-      OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
-      COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk lib/${ABI}/lib${APP_LIB_NAME}.so
+      OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.unaligned.apk
+      COMMAND zip -u ${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk lib/${ABI}/lib${APP_LIB_NAME}.so
 	  COMMAND ${CMAKE_COMMAND} -E copy
-              "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk"
-              "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk"
-      DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
-              ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so                      # Shared libraries as dependencies
+              "${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk"
+              "${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.unaligned.apk"
+      DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
+              ${CMAKE_BINARY_DIR}/lib/${ABI}/lib${APP_LIB_NAME}.so                           # Shared libraries as dependencies
       COMMENT "Adding shared libraries (${ABI})"
     )
   # For the universal APK (includes shared libraries for all ABIs)
   else()
-    # Gather all ABI-specific shared libraries into a list
-    set(SHARED_LIBS "")
-    foreach(ORIGINAL_ABI IN LISTS ORIGINAL_ABIS)
-	  list(APPEND SHARED_LIBS "lib/${ORIGINAL_ABI}/lib${APP_LIB_NAME}.so")
-	endforeach()
-	  
     add_custom_command(
-      OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
-      COMMAND zip -u ${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk ${SHARED_LIBS}
+      OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.unaligned.apk
+      COMMAND zip -u ${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk ${SHARED_LIBS}
       COMMAND ${CMAKE_COMMAND} -E copy
-              "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk"
-              "${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk"
-      DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
-              ${SHARED_LIBS}                                                            # Shared libraries as dependencies
+              "${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk"
+              "${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.unaligned.apk"
+      DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.base.apk  # Base APK as a dependency
+              ${SHARED_LIBS}                                                                 # Shared libraries as dependencies
       COMMENT "Adding shared libraries (${ABI})"
     )
   endif()
-  add_custom_target(add_shared_libs_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk)
+  add_custom_target(add_shared_libs_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.unaligned.apk)
 endforeach()
 
 # Align the APK packages for optimized installation on Android
 foreach(ABI IN LISTS ABIS)
   add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
+    OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.aligned.apk
     COMMAND zipalign -f                                  # Force overwrite
             -p                                           # Page aligns uncompressed data
             4                                            # Align ZIP to 4-byte boundaries
-            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
-            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
-    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.unaligned.apk
+            ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.unaligned.apk
+            ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.aligned.apk
+    DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.unaligned.apk
     COMMENT "Aligning APK package (${ABI})"
   )
-  add_custom_target(align_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk)
+  add_custom_target(align_apk_${ABI} ALL DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.aligned.apk)
 endforeach()
 
 # Check if the build type is Debug
@@ -247,43 +257,71 @@ endif()
 # Sign the APK packages
 foreach(ABI IN LISTS ABIS)
   add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
-           ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk.idsig
+    OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk
+           ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk.idsig
     COMMAND apksigner sign
             --ks ${KEYSTORE_PATH} --ks-pass pass:${KEYSTORE_PASS}
             --ks-key-alias ${KEY_ALIAS} --key-pass pass:${KEY_PASS}
-            --out ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
-            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
-    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.aligned.apk
+            --out ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk
+            ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.aligned.apk
+    DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}_${ABI}.aligned.apk
     COMMENT "Signing APK package (${ABI})"
   )
   add_custom_target(sign_apk_${ABI} ALL
-    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
-            ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk.idsig
+    DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk
+            ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk.idsig
   )
 endforeach()
-
-# Set default user ID
-if(NOT DEFINED USER_ID)
-  set(USER_ID 0 CACHE STRING "User ID (default 0, the primary user)")
-endif()
 
 # Install the APK packages
 # Use -e (emulator) or -d (device) flags with adb if needed
 foreach(ABI IN LISTS ABIS)
   add_custom_target(install_apk_${ABI}
-    COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
-    DEPENDS ${CMAKE_BINARY_DIR}/${APK_OUTPUT_DIR}/${APK_OUTPUT_NAME}_${ABI}.apk
+    COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk
+    DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk
     COMMENT "Installing APK package (${ABI})"
   )
 endforeach()
 
-# Define the application package name
-set(APK_PACKAGE_NAME "com.oussamateyib.helloworld")
+# Create an Android App Bundle (AAB) from compiled resources and native libraries
+add_custom_command(
+  OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+  # Link compiled resource files into an APK (intermediate step)
+  COMMAND aapt2 link
+          --proto-format                               # Use proto format for compatibility with bundletool
+          -o ${APP_OUTPUT_DIR}/temp/output.apk         # Output intermediate APK
+          ${COMPILED_RES_FILES}                        # Compiled resource files
+          --auto-add-overlay                           # Automatically overlay resources
+          -I ${ANDROID_JAR_PATH}                       # Android platform JAR
+          --manifest ${ANDROID_MANIFEST_FILE}          # AndroidManifest.xml
+  # Unzip the APK into the base module directory structure
+  COMMAND unzip -o -qq ${APP_OUTPUT_DIR}/temp/output.apk -d ${APP_OUTPUT_DIR}/temp/base
+  # Create the 'manifest' subdirectory as expected by bundletool
+  COMMAND ${CMAKE_COMMAND} -E make_directory ${APP_OUTPUT_DIR}/temp/base/manifest
+  # Move the manifest to its expected location under 'manifest/' in the base module
+  COMMAND ${CMAKE_COMMAND} -E rename
+          ${APP_OUTPUT_DIR}/temp/base/AndroidManifest.xml
+          ${APP_OUTPUT_DIR}/temp/base/manifest/AndroidManifest.xml
+  # Remove any existing zip to avoid conflicts
+  COMMAND ${CMAKE_COMMAND} -E remove -f ${APP_OUTPUT_DIR}/temp/base.zip
+  # Re-zip the base module contents into base.zip (required by bundletool)
+  COMMAND ${CMAKE_COMMAND} -E chdir ${APP_OUTPUT_DIR}/temp/base zip -r ../base.zip *
+  # Add native shared libraries to the zip
+  COMMAND zip -u ${APP_OUTPUT_DIR}/temp/base.zip ${SHARED_LIBS}
+  # Remove any existing unsigned AAB to avoid conflicts
+  COMMAND ${CMAKE_COMMAND} -E remove -f ${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+  # Build the final AAB file from base.
+  COMMAND bundletool build-bundle --modules=${APP_OUTPUT_DIR}/temp/base.zip --output=${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+  DEPENDS ${ANDROID_MANIFEST_FILE}                     # Manifest file as a dependency
+          ${COMPILED_RES_FILES}                        # Compiled resources as dependencies
+		  ${SHARED_LIBS}                               # Shared libraries as dependencies
+  COMMENT "Creating AAB bundle"
+)
+add_custom_target(create_aab DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab)
 
 # Uninstall the application from the connected device/emulator
 add_custom_target(uninstall_apk
-  COMMAND adb uninstall --user ${USER_ID} ${APK_PACKAGE_NAME}
+  COMMAND adb uninstall --user ${USER_ID} ${APP_PACKAGE_NAME}
   COMMENT "Uninstalling APK package"
 )
 
@@ -298,3 +336,7 @@ add_custom_target(list_users
   COMMAND adb shell pm list users
   COMMENT "Listing current users on device"
 )
+
+# Ensure that all untracked temporary files are removed when the `clean` target is invoked
+file(GLOB_RECURSE TEMP_FILES "${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/*")
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES ${TEMP_FILES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,10 +314,23 @@ add_custom_command(
   COMMAND bundletool build-bundle --modules=${APP_OUTPUT_DIR}/temp/base.zip --output=${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
   DEPENDS ${ANDROID_MANIFEST_FILE}                     # Manifest file as a dependency
           ${COMPILED_RES_FILES}                        # Compiled resources as dependencies
-		  ${SHARED_LIBS}                               # Shared libraries as dependencies
+          ${SHARED_LIBS}                               # Shared libraries as dependencies
   COMMENT "Creating AAB bundle"
 )
 add_custom_target(create_aab DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab)
+
+# Sign the AAB bundle
+add_custom_command(
+  OUTPUT ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab
+  COMMAND jarsigner
+          -keystore ${KEYSTORE_PATH} -storepass ${KEYSTORE_PASS}
+          -signedjar ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab
+          ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+          ${KEY_ALIAS}
+  DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+  COMMENT "Signing AAB bundle"
+)
+add_custom_target(sign_aab DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab)
 
 # Uninstall the application from the connected device/emulator
 add_custom_target(uninstall_apk
@@ -337,6 +350,33 @@ add_custom_target(list_users
   COMMENT "Listing current users on device"
 )
 
-# Ensure that all untracked temporary files are removed when the `clean` target is invoked
-file(GLOB_RECURSE TEMP_FILES "${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/*")
-set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES ${TEMP_FILES})
+# Define a list of untracked intermediate files to remove on clean
+set(TEMP_FILES
+   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/output.apk
+   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base/manifest/AndroidManifest.xml
+   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base/resources.pb
+   ${TEMP_RES_FILES}
+   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base.zip
+)
+# Add expected intermediate resource files to the list
+foreach(res_file IN LISTS RES_FILES)
+  # Compute path relative to RES_DIR
+  file(RELATIVE_PATH res_file_relative_path "${RES_DIR}" "${res_file}")
+
+  # Skip files under values/
+  if(res_file_relative_path MATCHES "^values/")
+    continue()
+  endif()
+
+  # Only transform paths that are NOT mipmap-anydpi-v26/
+  if(NOT res_file_relative_path MATCHES "^mipmap-anydpi-v26/")
+    # Insert '-v4' into folders like mipmap-hdpi/ → mipmap-hdpi-v4/
+    string(REGEX REPLACE "^([^/]+)-([^/]+)/" "\\1-\\2-v4/" res_file_relative_path "${res_file_relative_path}")
+  endif()
+
+  # Append the transformed or untouched path to TEMP_FILES
+  list(APPEND TEMP_FILES "${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base/res/${res_file_relative_path}")
+endforeach()
+
+# Register untracked intermediate files for cleanup
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${TEMP_FILES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,6 @@ if(NOT DEFINED API_LEVEL)
   set(API_LEVEL "21" CACHE STRING "API level (minSdkVersion)")
 endif()
 
-# Set default user ID
-if(NOT DEFINED USER_ID)
-  set(USER_ID 0 CACHE STRING "User ID (default 0, the primary user)")
-endif()
-
 # Set the app output file name
 set(APP_OUTPUT_NAME ${PROJECT_NAME}_v${PROJECT_VERSION})
 
@@ -277,7 +272,7 @@ endforeach()
 # Use -e (emulator) or -d (device) flags with adb if needed
 foreach(ABI IN LISTS ABIS)
   add_custom_target(install_apk_${ABI}
-    COMMAND adb install --user ${USER_ID} ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk
+    COMMAND adb install ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk
     DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}_${ABI}.apk
     COMMENT "Installing APK package (${ABI})"
   )
@@ -325,22 +320,33 @@ add_custom_command(
 )
 add_custom_target(create_aab DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab)
 
+# Install the AAB bundle
+add_custom_target(install_aab
+  # Remove any existing .apks file to avoid conflicts
+  COMMAND ${CMAKE_COMMAND} -E remove -f ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.apks
+  # Build the APK set (.apks) from the AAB bundle
+  COMMAND bundletool build-apks
+          --bundle=${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab
+          --output=${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.apks
+          --ks ${KEYSTORE_PATH} --ks-pass pass:${KEYSTORE_PASS}
+          --ks-key-alias ${KEY_ALIAS} --key-pass pass:${KEY_PASS}
+          --connected-device
+  # Install the generated .apks to the connected device
+  COMMAND bundletool install-apks --apks=${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.apks
+  DEPENDS ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/${APP_OUTPUT_NAME}.aab
+  COMMENT "Installing the AAB bundle"
+)
+
 # Uninstall the application from the connected device/emulator
-add_custom_target(uninstall_apk
-  COMMAND adb uninstall --user ${USER_ID} ${APP_PACKAGE_NAME}
-  COMMENT "Uninstalling APK package"
+add_custom_target(uninstall_app
+  COMMAND adb uninstall ${APP_PACKAGE_NAME}
+  COMMENT "Uninstalling the app package"
 )
 
 # Display the ABI of the connected device/emulator
 add_custom_target(check_device_abi
   COMMAND adb shell getprop ro.product.cpu.abi
   COMMENT "Checking device ABI compatibility"
-)
-
-# List all current users on the connected Android device/emulator
-add_custom_target(list_users
-  COMMAND adb shell pm list users
-  COMMENT "Listing current users on device"
 )
 
 # Define a list of untracked intermediate files to remove on clean
@@ -350,6 +356,7 @@ set(TEMP_FILES
   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base/resources.pb
   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/base.zip
   ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.unsigned.aab
+  ${CMAKE_BINARY_DIR}/${APP_OUTPUT_DIR}/temp/${APP_OUTPUT_NAME}.apks
 )
 # Add expected intermediate resource files to the list
 foreach(res_file IN LISTS RES_FILES)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Replace placeholders with your values before running the commands.
 
 ### Useful Commands
 
-- **Clean  the project**
+- **Clean the project**
   ```
   cmake --build <Build-Directory> --target clean
   ```
@@ -126,9 +126,9 @@ Replace placeholders with your values before running the commands.
   cmake --build <Build-Directory> --target uninstall_app
   ```
 
-- **Check device ABI**
+- **Check supported ABIs on the connected device or emulator**
   ```
-  cmake --build <Build-Directory> --target check_device_abi
+  cmake --build <Build-Directory> --target check_abi
   ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -81,61 +81,55 @@ Replace placeholders with your values before running the commands.
 
 2. **Build the project**
 
-   To generate APKs:
-   ```
-   cmake --build <Build-Directory>
-   ```
-   
-   This command compiles the native code and generates APKs for all configured ABIs, along with a universal APK that is compatible with all devices.
+   - To generate APKs:
+     ```
+     cmake --build <Build-Directory>
+     ```
+     This command compiles the native code and generates APKs for all configured ABIs, as well as a universal APK that works across all supported devices.
 
-   To generate an Android App Bundle (AAB):
-   ```
-   cmake --build <Build-Directory> --target create_aab
-   ```
-
-   This command compiles the native code (if not already compiled) and generates an AAB.
+   - To generate an Android App Bundle (AAB):
+     ```
+     cmake --build <Build-Directory> --target create_aab
+     ```
+     This command compiles the native code (if not already built) and generates an Android App Bundle (AAB).
 
 3. **Install on a connected device or emulator**
 
-   To install the APK for a specific ABI:
-   ```
-   cmake --build <Build-Directory> --target install_apk_<ABI-Name>
-   ```
-   
-   This command builds the native code and the APK for the specified ABI (if not already built), and installs it on the connected target.
-   > Replace `<ABI-Name>` with one of the configured ABIs.
+   - To install the APK for a specific ABI:
+     ```
+     cmake --build <Build-Directory> --target install_apk_<ABI-Name>
+     ```
+     This command builds the native code and the APK for the specified ABI (if not already built), then installs it on the connected device or emulator.
+     > Replace `<ABI-Name>` with one of the configured ABIs.
 
-   To install the universal APK:
-   ```
-   cmake --build <Build-Directory> --target install_apk_universal
-   ```
-   
-   This command builds the native code and the universal APK covering all configured ABIs (if not already built), and installs it on the connected target.
+   - To install the universal APK:
+     ```
+     cmake --build <Build-Directory> --target install_apk_universal
+     ```
+     This command builds the native code and a universal APK that supports all configured ABIs (if not already built), and installs it on the connected device or emulator.
 
-   To install the AAB:
-   ```
-   cmake --build <Build-Directory> --target install_aab
-   ```
-   
-   This command builds the native code and the AAB (if not already built), and installs it on the connected target.
-
+   - To install the AAB (Android App Bundle):
+     ```
+     cmake --build <Build-Directory> --target install_aab
+     ```
+     This command builds the native code and the AAB (if not already built), then installs it on the connected device or emulator.
 
 ### Useful Commands
 
 - **Clean  the project**
-   ```
-   cmake --build <Build-Directory> --target clean
-   ```
+  ```
+  cmake --build <Build-Directory> --target clean
+  ```
 
 - **Uninstall the app**
-   ```
-   cmake --build <Build-Directory> --target uninstall_app
-   ```
+  ```
+  cmake --build <Build-Directory> --target uninstall_app
+  ```
 
 - **Check device ABI**
-   ```
-   cmake --build <Build-Directory> --target check_device_abi
-   ```
+  ```
+  cmake --build <Build-Directory> --target check_device_abi
+  ```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Before you begin, ensure you have the following installed:
 - **Java Development Kit (JDK)** — JDK 11 or newer.
 - **raylib** — Follow the [official instructions](https://github.com/raysan5/raylib/wiki/Working-for-Android) to download and build raylib as a static library for Android
 
+If you plan to create Android App Bundles (AAB), the following must also be installed:
+- **AAPT2** — Follow the [official instructions](https://developer.android.com/build/building-cmdline#download_aapt2) to download an AAB-compatible version of AAPT2
+- **unzip**
+- **Bundletool**
+
 > ✅ Make sure all required tools are available in your system's PATH.
 
 > [!NOTE]
@@ -65,7 +70,6 @@ Replace placeholders with your values before running the commands.
          [-DCMAKE_BUILD_TYPE=<Build-Type>] \
          [-DABIS="<ABI-List>"] \
          [-DAPI_Level=<API-Level>] \
-         [-DUSER_ID=<User-ID>]
    ```
 
    **Explanation of Parameters:**
@@ -74,15 +78,22 @@ Replace placeholders with your values before running the commands.
    - `-DCMAKE_BUILD_TYPE=<Build-Type>` *(optional)* — One of: `Debug`, `Release`, `RelWithDebInfo`, `MinSizeRel` (default: `Debug`)
    - `-DABIS="<ABI-List>"` *(optional)* — ABIs to build for (default: `armeabi-v7a;arm64-v8a;x86;x86_64`)
    - `-DAPI_Level=<API-Level>` *(optional)* — Minimum Android API (default: `21`)
-   - `-DUSER_ID=<User-ID>` *(optional)* — Target user ID on device (efault: `0`, the primary user)
 
 2. **Build the project**
 
+   To generate APKs:
    ```
    cmake --build <Build-Directory>
    ```
-
+   
    This command compiles the native code and generates APKs for all configured ABIs, along with a universal APK that is compatible with all devices.
+
+   To generate an Android App Bundle (AAB):
+   ```
+   cmake --build <Build-Directory> --target create_aab
+   ```
+
+   This command compiles the native code (if not already compiled) and generates an AAB.
 
 3. **Install on a connected device or emulator**
 
@@ -91,7 +102,7 @@ Replace placeholders with your values before running the commands.
    cmake --build <Build-Directory> --target install_apk_<ABI-Name>
    ```
    
-   This command builds the native code and the APK for the specified ABI (if not already built), and installs it on the connected device or emulator.
+   This command builds the native code and the APK for the specified ABI (if not already built), and installs it on the connected target.
    > Replace `<ABI-Name>` with one of the configured ABIs.
 
    To install the universal APK:
@@ -101,6 +112,13 @@ Replace placeholders with your values before running the commands.
    
    This command builds the native code and the universal APK covering all configured ABIs (if not already built), and installs it on the connected target.
 
+   To install the AAB:
+   ```
+   cmake --build <Build-Directory> --target install_aab
+   ```
+   
+   This command builds the native code and the AAB (if not already built), and installs it on the connected target.
+
 
 ### Useful Commands
 
@@ -109,19 +127,14 @@ Replace placeholders with your values before running the commands.
    cmake --build <Build-Directory> --target clean
    ```
 
-- **Uninstall the APK**
+- **Uninstall the app**
    ```
-   cmake --build <Build-Directory> --target uninstall_apk
+   cmake --build <Build-Directory> --target uninstall_app
    ```
 
 - **Check device ABI**
    ```
    cmake --build <Build-Directory> --target check_device_abi
-   ```
-
-- **List users on the device**
-   ```
-   cmake --build <Build-Directory> --target list_users
    ```
 
 ## License


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds support for generating Android App Bundles (AAB) alongside the existing APK build flow, following the [official bundletool build guide](https://developer.android.com/build/building-cmdline#bundletool-build).

### Changes

- Extracted shared library gathering into a single `SHARED_LIBS` list computed once before the ABI loop, replacing the per-ABI `ORIGINAL_ABIS` logic used for the universal APK.
- Added a `create_aab` target that links resources in proto format, unpacks and restructures them into bundletool's expected module layout, packages them into a zip, builds the bundle with `bundletool build-bundle`, and signs it with `jarsigner`.
- Added an `install_aab` target that builds an APK set from the AAB using `bundletool build-apks` with the connected device's signing credentials, then installs it with `bundletool install-apks`.
- Renamed `uninstall_apk` target to `uninstall_app` and updated it to use `APP_PACKAGE_NAME`.
- Renamed `check_device_abi` target to `check_abi` and extended it to also display the device's full list of supported ABIs.
- Registered untracked intermediate files (compiled resources, manifest, zips, unsigned AAB, APKS) as additional clean files for the `clean` target.
- Updated `README.md` to document AAB prerequisites (AAPT2, unzip, Bundletool), the `create_aab` and `install_aab` build targets, and the renamed `check_abi`/`uninstall_app` commands.

### Related Issues

- Fixes #9