### PR TITLE
Include raylib as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "app/src/main/c/raylib"]
+	path = app/src/main/c/raylib
+	url = https://github.com/raysan5/raylib.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Before you begin, ensure you have the following installed:
 
 - **Java Development Kit (JDK)** — JDK 17
 
-If you plan to build a release version of the app, the following environement variables must be set:
+If you plan to build a release version of the app, the following environment variables must be set:
 - **STORE_FILE** — Path to the keystore used for signing
 - **STORE_PASSWORD** — Keystore password
 - **KEY_ALIAS** — Alias of the key in the keystore

--- a/README.md
+++ b/README.md
@@ -9,35 +9,8 @@ This is a simple Android application written in C that displays **"Hello, World!
 Before you begin, ensure you have the following installed:
 
 - **Java Development Kit (JDK)** — JDK 17
-- **raylib** — Follow the [official instructions](https://github.com/raysan5/raylib/wiki/Working-for-Android) to download and build raylib as a static library for Android
 
-> [!NOTE]
-> **By default**:
-> - Application name: `Hello World`
-> - Native library name: `main`
-> - Application package name: `com.oussamateyib.helloworld`
-> - Compile SDK version: `36`
-> - Target SDK version: `36`
-> - Minimum SDK version: `21`
-> 
-> If you change these defaults, you must update related configuration files.
-
-### Environment Variables
-
-Before building the project, ensure the following environment variables are set:
-
-- **ANDROID_EXTERNAL_HOME** — Path to the installation of external Android libraries. This directory must have the following structure:
-
-  ```plaintext
-  ANDROID_EXTERNAL_HOME/
-  ├── include/              # Contains header files for external libraries
-  │   └── raylib.h
-  └── lib/                  # Contains library files for different ABIs
-      ├── <ABI>/            # ABI name (e.g., armeabi-v7a, arm64-v8a)
-      │   └── libraylib.a   # Static raylib library for the ABI
-  ```
-  
-If you plan to build a release version of the app, the following variables must also be set (for signing):
+If you plan to build a release version of the app, the following environement variables must be set:
 - **STORE_FILE** — Path to the keystore used for signing
 - **STORE_PASSWORD** — Keystore password
 - **KEY_ALIAS** — Alias of the key in the keystore

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,10 +29,11 @@ android {
         externalNativeBuild {
             cmake {
                 arguments(
-                    "-DANDROID_EXTERNAL_HOME=${System.getenv("ANDROID_EXTERNAL_HOME")}",
-                    "-DAPP_LIB_NAME=main",
                     "-DCMAKE_C_STANDARD=23",
-                    "-DCMAKE_C_EXTENSIONS=OFF"
+                    "-DCMAKE_C_EXTENSIONS=OFF",
+                    "-DPLATFORM=Android",
+                    "-DBUILD_EXAMPLES=OFF",
+                    "-DAPP_LIB_NAME=main"
                 )
             }
         }
@@ -43,7 +44,7 @@ android {
         cmake {
             path = file("src/main/c/CMakeLists.txt")
             // CMake minimum required version
-            version = "3.22.1"
+            version = "4.0.2"
         }
     }
 

--- a/app/src/main/c/CMakeLists.txt
+++ b/app/src/main/c/CMakeLists.txt
@@ -1,28 +1,11 @@
 # Minimum CMake version required for this project
-cmake_minimum_required(VERSION 3.22.1)
-
-# Set default library name if not provided
-set(APP_LIB_NAME "main" CACHE STRING "Name of the native library")
+cmake_minimum_required(VERSION 4.0.2)
 
 # Define project name and programming language
 project(${APP_LIB_NAME} LANGUAGES C)
 
-# Verify that ANDROID_EXTERNAL_HOME is set
-if(NOT DEFINED ANDROID_EXTERNAL_HOME)
-  message(FATAL_ERROR "ANDROID_EXTERNAL_HOME is not set. Make sure it's passed to CMake")
-endif()
-
-# Paths for external Android libraries (e.g., raylib)
-set(EXTERNAL_INCLUDE_DIR "${ANDROID_EXTERNAL_HOME}/include")
-set(EXTERNAL_LIB_DIR "${ANDROID_EXTERNAL_HOME}/lib/${ANDROID_ABI}")
-
-# Import raylib static library
-add_library(raylib STATIC IMPORTED)
-set_target_properties(raylib PROPERTIES
-  IMPORTED_LOCATION "${EXTERNAL_LIB_DIR}/libraylib.a"
-  # Include directories that consumers of raylib should use
-  INTERFACE_INCLUDE_DIRECTORIES "${EXTERNAL_INCLUDE_DIR}"
-)
+# Import raylib
+add_subdirectory("raylib")
 
 # Source directory
 set(SOURCE_DIR "${CMAKE_SOURCE_DIR}")


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR replaces the manual, environment-variable-based integration of raylib with a git submodule, letting CMake build raylib directly as part of the project instead of requiring it to be pre-built and installed externally.

### Changes

- Added raylib as a git submodule under `app/src/main/c/raylib`, tracking the `master` branch.
- Bumped the minimum required CMake version from 3.22.1 to 4.0.2 in `app/src/main/c/CMakeLists.txt` and `app/build.gradle.kts`.
- Replaced the imported static raylib library and the `ANDROID_EXTERNAL_HOME`-based include/lib path resolution with `add_subdirectory("raylib")`.
- Removed the `ANDROID_EXTERNAL_HOME` requirement check, since raylib is now built from source.
- Updated `app/build.gradle.kts` to remove the `ANDROID_EXTERNAL_HOME` CMake argument and add `-DPLATFORM=Android` and `-DBUILD_EXAMPLES=OFF` arguments for building raylib.

### Related Issues

- Closes #16