### PR TITLE
Control symbol visibility with version script

### DIFF
--- a/app/src/main/c/CMakeLists.txt
+++ b/app/src/main/c/CMakeLists.txt
@@ -22,8 +22,17 @@ add_library(${APP_LIB_NAME} SHARED ${SOURCE_FILES})
 # Include directory for this library
 target_include_directories(${APP_LIB_NAME} PRIVATE "${SOURCE_DIR}")
 
-# Force inclusion of ANativeActivity_onCreate, expected by NativeActivity
-target_link_options(${APP_LIB_NAME} PRIVATE -u ANativeActivity_onCreate)
+# Configure linker options
+target_link_options(${APP_LIB_NAME} PRIVATE
+  -u ANativeActivity_onCreate                              # Force inclusion of ANativeActivity_onCreate, expected by NativeActivity
+  -Wl,--version-script,${CMAKE_SOURCE_DIR}/libmain.map.txt # Control symbol visibilitY
+  -Wl,--no-undefined-version                               # Ensure all symbols in the version script are defined
+)
+
+# Declare version script as a link dependency
+set_target_properties(${APP_LIB_NAME} PROPERTIES
+  LINK_DEPENDS ${CMAKE_SOURCE_DIR}/libmain.map.txt
+)
 
 # Link against essential Android libraries and raylib
 target_link_libraries(${APP_LIB_NAME} PRIVATE c m android log EGL GLESv2 OpenSLES raylib)

--- a/app/src/main/c/libmain.map.txt
+++ b/app/src/main/c/libmain.map.txt
@@ -1,6 +1,6 @@
 LIBMAIN {
-    global:
-        ANativeActivity_onCreate;
-    local:
-        *;
+  global:
+    ANativeActivity_onCreate;
+  local:
+    *;
 };

--- a/app/src/main/c/libmain.map.txt
+++ b/app/src/main/c/libmain.map.txt
@@ -1,0 +1,6 @@
+LIBMAIN {
+    global:
+        ANativeActivity_onCreate;
+    local:
+        *;
+};


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds a version script to control symbol visibility in the native shared library. Previously, all symbols (including raylib internals) were exported globally, increasing load time and binary size. Now only `ANativeActivity_onCreate` is exported; everything else is hidden.

### Testing

Verified with `nm -D libmain.so | grep " T "` — only `ANativeActivity_onCreate@@LIBMAIN` is exported.
