### PR TITLE
Configure Renovate to automatically merge low-risk dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,12 @@
   ],
   "labels": [
     "dependencies"
+  ],
+  "assigneesFromCodeOwners": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR updates the Renovate configuration to enable automatic merging of low-risk dependency updates, reducing manual overhead for routine maintenance. For updates that cannot be auto-merged — such as major version bumps or when CI fails — code owners are automatically assigned.
