### PR TITLE
Migrate JVM configuration to Java toolchain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,13 @@
 
 ## 1. Project Overview
 
-**HelloWorld** is a minimal Android application written entirely in **C** using the [raylib](https://github.com/raysan5/raylib) graphics library. It renders the text *"Hello, world!"* centered on a fullscreen window, with the font size calculated dynamically to fill 80 % of the available screen area.
+**HelloWorld** is a minimal Android application written entirely in **C** using
+the [raylib](https://github.com/raysan5/raylib) graphics library. It renders the text *"Hello,
+world!"* centered on a fullscreen window, with the font size calculated dynamically to fill 80 % of
+the available screen area.
 
 | Property         | Value                                        |
-| ---------------- | -------------------------------------------- |
+|------------------|----------------------------------------------|
 | Language         | C (standard: C23, extensions off)            |
 | Graphics library | raylib (git submodule, `master` branch)      |
 | Build system     | Gradle + CMake                               |
@@ -76,7 +79,9 @@ HelloWorld/
 
 ## 3. Architecture
 
-The application is **fully native** — there is no Kotlin or Java runtime code (`android:hasCode="false"` in the manifest). The Android framework loads the native shared library (`libmain.so`) directly via `NativeActivity`.
+The application is **fully native** — there is no Kotlin or Java runtime code (
+`android:hasCode="false"` in the manifest). The Android framework loads the native shared library (
+`libmain.so`) directly via `NativeActivity`.
 
 ```plaintext
 Android NativeActivity
@@ -91,7 +96,8 @@ Android NativeActivity
 
 `x86`, `x86_64`, `armeabi-v7a`, `arm64-v8a`, `riscv64`
 
-> ABI splits are enabled for APK builds and disabled automatically for AAB builds to avoid conflicts.
+> ABI splits are enabled for APK builds and disabled automatically for AAB builds to avoid
+> conflicts.
 
 ---
 
@@ -99,12 +105,12 @@ Android NativeActivity
 
 ### Prerequisites
 
-| Tool        | Version                      |
-| ----------- | ---------------------------- |
-| JDK         | 17                           |
-| CMake       | ≥ 3.25.0                     |
-| Android SDK | Managed automatically by AGP |
-| Android NDK | Managed automatically by AGP |
+| Tool        | Version                             |
+|-------------|-------------------------------------|
+| JDK         | 17 (Managed automatically by Gradle |
+| CMake       | ≥ 3.25.0                            |
+| Android SDK | Managed automatically by AGP        |
+| Android NDK | Managed automatically by AGP        |
 
 ### Gradle tasks
 
@@ -131,7 +137,7 @@ Android NativeActivity
 ### CMake flags (set automatically by Gradle)
 
 | Flag                 | Value     | Purpose                            |
-| -------------------- | --------- | ---------------------------------- |
+|----------------------|-----------|------------------------------------|
 | `CMAKE_C_STANDARD`   | `23`      | Enforce C23                        |
 | `CMAKE_C_EXTENSIONS` | `OFF`     | Disable compiler extensions        |
 | `PLATFORM`           | `Android` | Tell raylib to target Android      |
@@ -143,7 +149,7 @@ Android NativeActivity
 Release builds read signing credentials from the following **environment variables**:
 
 | Variable         | Description                                            |
-| ---------------- | ------------------------------------------------------ |
+|------------------|--------------------------------------------------------|
 | `STORE_FILE`     | Absolute path to the `.jks` / `.p12` keystore          |
 | `STORE_PASSWORD` | Keystore password                                      |
 | `KEY_ALIAS`      | Key alias inside the keystore                          |
@@ -164,20 +170,23 @@ If none of these are set, the release build falls back to the **debug keystore**
 ### C code (`app/src/main/c/`)
 
 - **Style**: Follow the existing style in `main.c`:
-  - 4-space indentation (no tabs).
-  - `const` whenever a variable is not reassigned.
-  - Guard all public utility functions against invalid input (null pointers, non-positive dimensions, etc.).
-  - Keep the render loop free of heap allocations.
+    - 4-space indentation (no tabs).
+    - `const` whenever a variable is not reassigned.
+    - Guard all public utility functions against invalid input (null pointers, non-positive
+      dimensions, etc.).
+    - Keep the render loop free of heap allocations.
 - **Comments**: Use `//` line comments for inline explanations; keep comments concise and accurate.
 
 ### CMake (`CMakeLists.txt`)
 
-- New C sources in `app/src/main/c/` are picked up automatically via `GLOB_RECURSE` — no manual `target_sources` additions needed.
+- New C sources in `app/src/main/c/` are picked up automatically via `GLOB_RECURSE` — no manual
+  `target_sources` additions needed.
 
 ### Gradle (`.gradle.kts` files)
 
 - Use **Kotlin DSL** (`.kts`) — do not introduce Groovy build scripts.
-- Add new dependencies through the **version catalog** (`gradle/libs.versions.toml`), not as inline strings.
+- Add new dependencies through the **version catalog** (`gradle/libs.versions.toml`), not as inline
+  strings.
 
 ### XML / Resources
 
@@ -235,7 +244,8 @@ All workflows are defined in `.github/workflows/`.
 3. Build APKs and AABs, signing with keystore secrets.
 4. Run lint.
 5. Rename artifacts to a consistent `HelloWorld_*` naming scheme.
-6. Upload artifacts: debug/release APKs, debug/release AABs, native debug symbols, ProGuard mapping, build logs, lint reports.
+6. Upload artifacts: debug/release APKs, debug/release AABs, native debug symbols, ProGuard mapping,
+   build logs, lint reports.
 7. Generate **build-provenance attestations** for all output artifacts.
 
 ### `release.yml` — triggered on version tag push
@@ -243,7 +253,8 @@ All workflows are defined in `.github/workflows/`.
 1. Build and sign release APKs and AABs.
 2. Rename artifacts to `HelloWorld_<version>_*`, move ProGuard mapping and native debug symbols.
 3. Generate `SHA256SUMS` and sign it with GPG.
-4. Create a GitHub Release with auto-generated notes, attach APKs, AAB, mapping, native debug symbols, `SHA256SUMS`, and `SHA256SUMS.asc`. Also opens a discussion under **Announcements**.
+4. Create a GitHub Release with auto-generated notes, attach APKs, AAB, mapping, native debug
+   symbols, `SHA256SUMS`, and `SHA256SUMS.asc`. Also opens a discussion under **Announcements**.
 
 ### `dependency-submission.yml` — triggered on
 
@@ -266,7 +277,7 @@ Runs GitHub's CodeQL static analysis on `c-cpp`.
 ## 8. Important Constraints
 
 | Rule                                                  | Reason                                                                                                                   |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+|-------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------|
 | **Do not add Kotlin or Java source files.**           | The app is fully native (`android:hasCode="false"`).                                                                     |
 | **Do not edit files under `app/src/main/c/raylib/`.** | This is a git submodule. Changes there will be lost on the next `submodule update` and will not be tracked in this repo. |
 | **Always use `./gradlew`, never `gradle`.**           | The wrapper pins the exact Gradle version required for reproducible builds.                                              |

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # HelloWorld
 
-
 [![Build](https://github.com/OussamaTeyib/HelloWorld/actions/workflows/build.yml/badge.svg)](https://github.com/OussamaTeyib/HelloWorld/actions/workflows/build.yml)
 [![CodeQL](https://github.com/OussamaTeyib/HelloWorld/actions/workflows/codeql.yml/badge.svg)](https://github.com/OussamaTeyib/HelloWorld/actions/workflows/codeql.yml)
 [![Dependency Submission](https://github.com/OussamaTeyib/HelloWorld/actions/workflows/dependency-submission.yml/badge.svg)](https://github.com/OussamaTeyib/HelloWorld/actions/workflows/dependency-submission.yml)
 
-This is a simple Android application written in C that displays **"Hello, world!"** using [raylib](https://github.com/raysan5/raylib).
+This is a simple Android application written in C that displays **"Hello, world!"**
+using [raylib](https://github.com/raysan5/raylib).
 
 ---
 
 ## Getting Started
 
 > [!TIP]
-> This workflow uses Gradle. For a CMake-only workflow, which offers greater flexibility, see [this](https://github.com/OussamaTeyib/HelloWorld/tree/legacy).
+> This workflow uses Gradle. For a CMake-only workflow, which offers greater flexibility,
+> see [this](https://github.com/OussamaTeyib/HelloWorld/tree/legacy).
 
 ### Prerequisites
 
 Before you begin, ensure you have the following installed:
 
-- **Java Development Kit (JDK)** — JDK 17
 - **CMake** version 3.25.0 or higher
 
 If you want to use your own signing key for release builds, set the following environment variables:
@@ -32,52 +32,52 @@ If you want to use your own signing key for release builds, set the following en
 
 1. Set up the repository:
 
-   - Clone the repository and automatically initialize and update all submodules:
+    - Clone the repository and automatically initialize and update all submodules:
 
-     ```bash
-     git clone --recurse-submodules https://github.com/OussamaTeyib/HelloWorld.git
-     ```
+      ```bash
+      git clone --recurse-submodules https://github.com/OussamaTeyib/HelloWorld.git
+      ```
 
 2. Build the project:
 
-   - Using Android Studio:
-     - Open the project in Android Studio.
-     - Let Gradle sync.
-     - Use **Run** to launch on a device or emulator.
-     - Use **Build** > **Build Bundle(s) / APK(s)** to generate APK or AAB.
-  
-   - Using Terminal:
-     > `<Build-Type>` can be either `Debug` or `Release`.
+    - Using Android Studio:
+        - Open the project in Android Studio.
+        - Let Gradle sync.
+        - Use **Run** to launch on a device or emulator.
+        - Use **Build** > **Build Bundle(s) / APK(s)** to generate APK or AAB.
 
-     - Generate APKs:
+    - Using Terminal:
+      > `<Build-Type>` can be either `Debug` or `Release`.
 
-       ```bash
-       ./gradlew assemble<Build-Type>
-       ```
+        - Generate APKs:
 
-     - Install the APKs on a connected device or emulator:
+          ```bash
+          ./gradlew assemble<Build-Type>
+          ```
 
-       ```bash
-       ./gradlew install<Build-Type>
-       ```
+        - Install the APKs on a connected device or emulator:
 
-     - Uninstall the APKs:
+          ```bash
+          ./gradlew install<Build-Type>
+          ```
 
-       ```bash
-       ./gradlew uninstall<Build-Type>
-       ```
+        - Uninstall the APKs:
 
-     - Generate AABs:
+          ```bash
+          ./gradlew uninstall<Build-Type>
+          ```
 
-       ```bash
-       ./gradlew bundle<Build-Type>
-       ```
+        - Generate AABs:
 
-     - Clean the project
+          ```bash
+          ./gradlew bundle<Build-Type>
+          ```
 
-       ```bash
-       ./gradlew clean
-       ```
+        - Clean the project
+
+          ```bash
+          ./gradlew clean
+          ```
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,14 +1,17 @@
-// Apply Android application plugin
 plugins {
     alias(libs.plugins.android.application)
+}
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 // Detect if the current build is for an Android App Bundle (AAB)
 val isBuildingBundle = gradle.startParameter.taskNames.any { it.lowercase().contains("bundle") }
 
-// Android configuration
 android {
-    // Application configuration
     namespace = "com.oussamateyib.helloworld"
     compileSdk = 37
 
@@ -19,9 +22,9 @@ android {
         versionCode = 5
         versionName = "1.1.3"
 
-        // CMake build arguments
         externalNativeBuild {
             cmake {
+                // CMake build arguments
                 arguments(
                     "-DCMAKE_C_STANDARD=23",
                     "-DCMAKE_C_EXTENSIONS=OFF",
@@ -33,7 +36,6 @@ android {
         }
     }
 
-    // CMake configuration
     externalNativeBuild {
         cmake {
             path = file("src/main/c/CMakeLists.txt")
@@ -42,13 +44,6 @@ android {
         }
     }
 
-    // Java configuration
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-            
-    // ABI splits configuration
     splits {
         abi {
             // Disable ABI splits when building an App Bundle to avoid conflicts
@@ -62,7 +57,6 @@ android {
         }
     }
 
-    // Signing configuration
     signingConfigs {
         create("release") {
             // Use environment variables if provided
@@ -78,7 +72,6 @@ android {
         }
     }
 
-    // Build types configuration
     buildTypes {
         getByName("debug") {
             isJniDebuggable = true
@@ -110,7 +103,7 @@ android {
             signingConfig = if (System.getenv("STORE_FILE") != null) {
                 signingConfigs.getByName("release")
             } else {
-                signingConfigs.getByName("debug")  // Fallback to debug keystore
+                signingConfigs.getByName("debug") // Fallback to debug keystore
             }
 
             // Exclude dependency metadata
@@ -124,7 +117,6 @@ android {
         }
     }
 
-    // lint configuration
     lint {
         checkAllWarnings = true
         warningsAsErrors = true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-// Declare Android application plugin
 plugins {
     alias(libs.plugins.android.application) apply false
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
-// Plugin repositories
 pluginManagement {
     repositories {
+        gradlePluginPortal()
         google {
             content {
                 includeGroupByRegex("com\\.android.*")
@@ -12,7 +12,10 @@ pluginManagement {
     }
 }
 
-// Dependency repositories
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
+
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
@@ -27,6 +30,5 @@ dependencyResolutionManagement {
     }
 }
 
-// Project name and modules
 rootProject.name = "HelloWorld"
 include(":app")


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adopts the Java toolchain approach, where a single declaration covers Java and Kotlin compilation and automatically supplies source and target compatibility. Gradle also handles JDK provisioning automatically via a toolchain resolver, so developers no longer need to install JDK manually.

### Reference

- [Android docs](https://developer.android.com/build/jdks#toolchain)
- [Kotlin docs](https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support)
