### PR TITLE
Suppress version-related lint warnings

### DIFF
--- a/lint.xml
+++ b/lint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<lint>
+    <issue id="AndroidGradlePluginVersion" severity="ignore" />
+    <issue id="GradleDependency" severity="ignore" />
+    <issue id="NewerVersionAvailable" severity="ignore" />
+</lint>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

Adds a `lint.xml` configuration file to suppress lint warnings related to Gradle plugin and dependency versions, preventing the build from failing due to these non-critical issues.
