### PR TITLE
Update JDK to 21 for `dependency-submission` workflow

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -19,5 +19,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v6


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices
