### PR TITLE
Fix theme handling for dark mode and display cutouts

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="NightAdjusted.Theme.HelloWorld" parent="android:Theme.Material.NoActionBar" />
+</resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="Theme.HelloWorld" parent="android:Theme.DeviceDefault.NoActionBar" />
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <style name="NightAdjusted.Theme.HelloWorld" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <style name="Theme.HelloWorld" parent="NightAdjusted.Theme.HelloWorld">
+        <item name="android:forceDarkAllowed" tools:targetApi="29">false</item>
+    </style>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,5 +5,6 @@
 
     <style name="Theme.HelloWorld" parent="NightAdjusted.Theme.HelloWorld">
         <item name="android:forceDarkAllowed" tools:targetApi="29">false</item>
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="28">always</item>
     </style>
 </resources>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR introduces a dedicated night theme for the app and adjusts the base theme to prevent Android's automatic force-dark from altering the app's appearance, while also ensuring content is laid out under display cutouts.
