### PR TITLE
Add a target for clearing app data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -167,6 +167,7 @@ install_aab [manual]  ──delegates to──►  install_apks_connected_device
 | `export_spec`           | Export the connected device specifications to a JSON file |
 | `install_apk_<ABI>`     | Install the connected device's APK set                    |
 | `install_apk_universal` | Install the universal APK set on the connected device     |
+| `clear_app_data`        | Clear the application's data on the connected device      |
 | `uninstall_app`         | Uninstall the application from the connected device       |
 | `check_abis`            | Display the ABIs supported by the connected device        |
 
@@ -290,6 +291,9 @@ cmake --build <Build-Directory> --target create_apks_connected_device
 # Install the connected device's APK set
 cmake --build <Build-Directory> --target export_spec
 cmake --build <Build-Directory> --target install_apks_connected_device
+
+# Clear the application's data on the connected device
+cmake --build <Build-Directory> --target clear_app_data
 
 # Uninstall the app from the connected device
 cmake --build <Build-Directory> --target uninstall_app

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,6 +590,12 @@ add_custom_target(uninstall_app
   COMMENT "Uninstalling the application"
 )
 
+# Clear the application's data on the connected device
+add_custom_target(clear_app_data
+  COMMAND adb shell pm clear --user ${DEVICE_USER} ${APP_PACKAGE_NAME}
+  COMMENT "Clearing the application's data"
+)
+
 # Lint the project for code quality issues
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   # For debug builds, allow hardcoding the debug mode in the manifest

--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ If you want to use your own signing key for release builds, set the following en
      cmake --build <Build-Directory> --target install_apks_connected_device
      ```
 
+   - Clear the application's data on the connected device:
+
+     ```bash
+     cmake --build <Build-Directory> --target clear_app_data
+     ```
+
    - Uninstall the app from the connected device:
 
      ```bash


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds a new CMake target that clears the connected device's app data with a single command.
