### PR TITLE
Add a target for streaming application logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,7 @@ install_aab [manual]  ──delegates to──►  install_apks_connected_device
 | `clear_app_data`        | Clear the application's data on the connected device      |
 | `uninstall_app`         | Uninstall the application from the connected device       |
 | `check_abis`            | Display the ABIs supported by the connected device        |
+| `logcat`                | Stream application logs                                   |
 
 ### Supported ABIs
 
@@ -303,6 +304,9 @@ cmake --build <Build-Directory> --target lint
 
 # Display the connected device's supported ABIs
 cmake --build <Build-Directory> --target check_abis
+
+# Stream application logs
+cmake --build <Build-Directory> --target logcat
 
 # Export the connected device spec to a JSON file
 cmake --build <Build-Directory> --target export_spec

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -652,6 +652,14 @@ add_custom_target(check_abis
   COMMENT "Querying device ABIs"
 )
 
+# Stream the application logs from the connected device
+add_custom_target(logcat
+  COMMAND adb logcat -c
+  COMMAND adb logcat -v color -v brief raylib:V DEBUG:V AndroidRuntime:E *:S
+  USES_TERMINAL
+  COMMENT "Streaming application logs"
+)
+
 # Export the connected device specifications to a JSON file
 add_custom_command(
   OUTPUT "${APP_INTERM_DIR}/connected-device-spec.json"

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ If you want to use your own signing key for release builds, set the following en
      cmake --build <Build-Directory> --target check_abis
      ```
 
+   - Stream the application logs from the connected device:
+
+     ```bash
+     cmake --build <Build-Directory> --target logcat
+     ```
+
    - Export the connected device specifications to a JSON file:
 
      ```bash


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR adds a new `logcat` build target that streams application logs from the connected Android device, filtered to `raylib`, `DEBUG`, and `AndroidRuntime` tags, and clears the log buffer before streaming starts.
