### PR TITLE
Remove deprecated `sarifReport` lint property

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,7 +126,6 @@ android {
     lint {
         checkAllWarnings = true
         checkDependencies = true
-        sarifReport = true
         warningsAsErrors = true
     }
 }


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR removes the deprecated `sarifReport` property from the lint configuration. 
AGP now generates SARIF reports automatically by default.
