### PR TITLE
Enable parallel model fetching during Gradle Sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,7 @@ org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
 # Enable parallel task execution
 org.gradle.parallel=true
+# Enable parallel model fetching during Gradle Sync
+org.gradle.tooling.parallel=true
 # Show all warnings during builds
 org.gradle.warning.mode=all


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request
- [x] I have verified that there are no overlapping pull-requests open
- [x] I have verified that I am following the existing coding patterns and practices

### Description

This PR explicitly enables `org.gradle.tooling.parallel` to fix a Gradle Sync slowdown in Android Studio Quail 1, where the IDE stopped honoring `org.gradle.parallel=true` and fell back to sequential module processing. This restores concurrent module fetching for multi-module projects without affecting command-line builds.
